### PR TITLE
Fix syntax on setting project from envvar

### DIFF
--- a/pytest_ibutsu.py
+++ b/pytest_ibutsu.py
@@ -142,7 +142,7 @@ class IbutsuArchiver(object):
             )
         # If the project is set via environment variables
         if os.environ.get("IBUTSU_PROJECT"):
-            self.extra_data.update({"project", os.environ.get("IBUTSU_PROJECT")})
+            self.extra_data.update({"project": os.environ.get("IBUTSU_PROJECT")})
 
     def _status_to_summary(self, status):
         return {


### PR DESCRIPTION
Syntax error, triggers an exception like the following if `IBUTSU_PROJECT` is set in the environment.

```
INTERNALERROR>   File "/home/jenkins/workspace/shriver-ibutsu-testing-68-tier1/.env/lib64/python3.8/site-packages/pytest_ibutsu.py", line 625, in pytest_configure
INTERNALERROR>     ibutsu = IbutsuSender(ibutsu_server, ibutsu_source, extra_data=ibutsu_data)
INTERNALERROR>   File "/home/jenkins/workspace/shriver-ibutsu-testing-68-tier1/.env/lib64/python3.8/site-packages/pytest_ibutsu.py", line 475, in __init__
INTERNALERROR>     super().__init__(source=source, path=path, extra_data=extra_data)
INTERNALERROR>   File "/home/jenkins/workspace/shriver-ibutsu-testing-68-tier1/.env/lib64/python3.8/site-packages/pytest_ibutsu.py", line 145, in __init__
INTERNALERROR>     self.extra_data.update({"project", os.environ.get("IBUTSU_PROJECT")})
INTERNALERROR> ValueError: dictionary update sequence element #0 has length 7; 2 is required
```