### PR TITLE
Restrict the dependency of the Ibutsu client

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,4 +35,4 @@ install_requires=
     pre-commit
     pytest
     certifi
-    ibutsu-client
+    ibutsu-client<=1.1.0


### PR DESCRIPTION
Restrict the dependency of the Ibutsu client so that it doesn't break the pytest plugin