### PR TITLE
Run artifacts

### DIFF
--- a/src/pytest_ibutsu/modeling.py
+++ b/src/pytest_ibutsu/modeling.py
@@ -8,7 +8,6 @@ from typing import ClassVar
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Union
 
 import attr
@@ -16,9 +15,6 @@ import cattrs
 import pytest
 from attrs import asdict
 from attrs import Attribute
-
-if TYPE_CHECKING:
-    from pytest_ibutsu.pytest_plugin import IbutsuPlugin
 
 
 def _safe_string(obj):
@@ -144,8 +140,8 @@ class TestRun:
         return metadata
 
     @classmethod
-    def from_xdist_test_runs(cls, plugin: "IbutsuPlugin") -> "TestRun":
-        runs = plugin.workers_runs
+    def from_xdist_test_runs(cls, runs: List["TestRun"]) -> "TestRun":
+        results = [result for run in runs for result in run._results]
         return TestRun(
             component=runs[0].component,
             env=runs[0].env,
@@ -154,9 +150,9 @@ class TestRun:
             source=runs[0].source,
             start_time=min(runs, key=lambda run: run.start_time).start_time,
             duration=max(runs, key=lambda run: run.duration).duration,
-            summary=Summary.from_results(list(plugin.results.values())),
+            summary=Summary.from_results(results),
             artifacts=runs[0]._artifacts,
-            results=[result for run in runs for result in run._results],
+            results=results,
         )
 
     @classmethod

--- a/src/pytest_ibutsu/modeling.py
+++ b/src/pytest_ibutsu/modeling.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import Union
 
 import attr
@@ -15,6 +16,9 @@ import cattrs
 import pytest
 from attrs import asdict
 from attrs import Attribute
+
+if TYPE_CHECKING:
+    from pytest_ibutsu.pytest_plugin import IbutsuPlugin
 
 
 def _safe_string(obj):
@@ -67,6 +71,15 @@ class Summary:
             current_count = getattr(self, attr)
             setattr(self, attr, current_count + 1)
         self.tests += 1
+        self.collected += 1
+
+    @classmethod
+    def from_results(cls, results: List["TestResult"]) -> "Summary":
+        summary = cls()
+        for result in results:
+            summary.increment(result)
+        summary.collected = len(results)
+        return summary
 
 
 @attr.s(auto_attribs=True)
@@ -78,7 +91,9 @@ class TestRun:
     source: Optional[str] = None
     start_time: str = ""
     duration: float = 0.0
+    _results: List["TestResult"] = attr.ib(factory=list)
     _start_unix_time: float = attr.ib(init=False, default=0.0)
+    _artifacts: Dict[str, Union[bytes, str]] = attr.ib(factory=dict)
     summary: Summary = attr.ib(factory=Summary)
     # TODO backwards compatibility
     _data: Dict = attr.ib(factory=dict)
@@ -111,8 +126,8 @@ class TestRun:
         if self._start_unix_time:
             self.duration = time.time() - self._start_unix_time
 
-    def set_summary_collected(self, session: pytest.Session) -> None:
-        self.summary.collected = getattr(session, "testscollected", self.summary.tests)
+    def attach_artifact(self, name: str, content: Union[bytes, str]) -> None:
+        self._artifacts[name] = content
 
     def to_dict(self) -> dict:
         return asdict(
@@ -129,16 +144,35 @@ class TestRun:
         return metadata
 
     @classmethod
-    def from_test_runs(cls, runs: List["TestRun"]) -> "TestRun":
+    def from_xdist_test_runs(cls, plugin: "IbutsuPlugin") -> "TestRun":
+        runs = plugin.workers_runs
         return TestRun(
             component=runs[0].component,
             env=runs[0].env,
             id=runs[0].id,
             metadata=cls.get_metadata(runs),
             source=runs[0].source,
-            start_time=cls.get_start_time(runs),
-            duration=cls.get_duration(runs),
-            summary=cls.combine_summaries(runs),
+            start_time=min(runs, key=lambda run: run.start_time).start_time,
+            duration=max(runs, key=lambda run: run.duration).duration,
+            summary=Summary.from_results(list(plugin.results.values())),
+            artifacts=runs[0]._artifacts,
+            results=[result for run in runs for result in run._results],
+        )
+
+    @classmethod
+    def from_sequential_test_runs(cls, runs: List["TestRun"]) -> "TestRun":
+        latest_run = max(runs, key=lambda run: run.start_time)
+        return TestRun(
+            component=latest_run.component,
+            env=latest_run.env,
+            id=latest_run.id,
+            metadata=cls.get_metadata(runs),
+            source=latest_run.source,
+            start_time=min(runs, key=lambda run: run.start_time).start_time,
+            duration=sum(run.duration for run in runs),
+            summary=Summary.from_results(latest_run._results),
+            artifacts=latest_run._artifacts,
+            results=latest_run._results,
         )
 
     @classmethod
@@ -186,7 +220,7 @@ class TestResult:
         return self._data.get(key, default)
 
     @staticmethod
-    def _get_item_params(item: pytest.Item) -> dict:
+    def _get_item_params(item: pytest.Item) -> Dict:
         def get_name(obj):
             return getattr(obj, "_param_name", None) or getattr(obj, "name", None) or str(obj)
 
@@ -226,19 +260,21 @@ class TestResult:
     def from_item(cls, item: pytest.Item) -> "TestResult":
         from .pytest_plugin import ibutsu_plugin_key
 
+        ibutsu_plugin = item.config.stash[ibutsu_plugin_key]
         return cls(
             test_id=cls._get_test_idents(item),
             params=cls._get_item_params(item),
-            source=item.config.stash[ibutsu_plugin_key].ibutsu_source,
-            run_id=item.config.stash[ibutsu_plugin_key].run.id,
+            source=ibutsu_plugin.ibutsu_source,
+            run_id=ibutsu_plugin.run.id,
             metadata={
                 "statuses": {},
-                "run": item.config.stash[ibutsu_plugin_key].run.id,
+                "run": ibutsu_plugin.run.id,
                 "durations": {},
                 "fspath": cls._get_item_fspath(item),
                 "markers": cls._get_item_markers(item),
-                "project": item.config.stash[ibutsu_plugin_key].ibutsu_project,
-                **item.config.stash[ibutsu_plugin_key].run.metadata,
+                "project": ibutsu_plugin.ibutsu_project,
+                "node_id": item.nodeid,
+                **ibutsu_plugin.run.metadata,
             },
         )
 

--- a/src/pytest_ibutsu/modeling.py
+++ b/src/pytest_ibutsu/modeling.py
@@ -74,14 +74,14 @@ class TestRun:
     component: Optional[str] = None
     env: Optional[str] = None
     id: str = attr.ib(factory=lambda: str(uuid.uuid4()))
-    metadata: dict = attr.ib(factory=dict)
+    metadata: Dict = attr.ib(factory=dict)
     source: Optional[str] = None
     start_time: str = ""
     duration: float = 0.0
     _start_unix_time: float = attr.ib(init=False, default=0.0)
     summary: Summary = attr.ib(factory=Summary)
     # TODO backwards compatibility
-    _data: dict = attr.ib(factory=dict)
+    _data: Dict = attr.ib(factory=dict)
 
     def __getitem__(self, key):
         # TODO backwards compatibility
@@ -122,29 +122,7 @@ class TestRun:
         )
 
     @staticmethod
-    def combine_summaries(runs: List["TestRun"]) -> Summary:
-        summary = Summary()
-        for run in runs:
-            summary.failures += run.summary.failures
-            summary.errors += run.summary.errors
-            summary.xfailures += run.summary.xfailures
-            summary.xpasses += run.summary.xpasses
-            summary.skips += run.summary.skips
-            summary.tests += run.summary.tests
-            summary.not_run += run.summary.not_run
-            summary.collected += run.summary.collected
-        return summary
-
-    @staticmethod
-    def get_start_time(runs: List["TestRun"]) -> str:
-        return min(runs, key=lambda run: run.start_time).start_time
-
-    @staticmethod
-    def get_duration(runs: List["TestRun"]) -> float:
-        return max(runs, key=lambda run: run.duration).duration
-
-    @staticmethod
-    def get_metadata(runs: List["TestRun"]) -> dict:
+    def get_metadata(runs: List["TestRun"]) -> Dict:
         metadata = {}
         for run in runs:
             metadata.update(run.metadata)
@@ -185,15 +163,15 @@ class TestResult:
     env: Optional[str] = None
     result: str = "passed"
     id: str = attr.ib(factory=lambda: str(uuid.uuid4()))
-    metadata: dict = attr.ib(factory=dict)
-    params: dict = attr.ib(factory=dict)
+    metadata: Dict = attr.ib(factory=dict)
+    params: Dict = attr.ib(factory=dict)
     run_id: Optional[str] = None
     source: str = "local"
     start_time: str = ""
     duration: float = 0.0
     _artifacts: Dict[str, Union[bytes, str]] = attr.ib(factory=dict)
     # TODO backwards compatibility
-    _data: dict = attr.ib(factory=dict)
+    _data: Dict = attr.ib(factory=dict)
 
     def __getitem__(self, key):
         # TODO backwards compatibility
@@ -382,7 +360,7 @@ class TestResult:
     def attach_artifact(self, name: str, content: Union[bytes, str]) -> None:
         self._artifacts[name] = content
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Dict:
         return asdict(
             self,
             filter=lambda attr, _: not attr.name.startswith("_"),

--- a/src/pytest_ibutsu/pytest_plugin.py
+++ b/src/pytest_ibutsu/pytest_plugin.py
@@ -272,7 +272,7 @@ class IbutsuPlugin:
             session.config.workeroutput["results"] = pickle.dumps(self.results)
             return
         if is_xdist_controller(session.config):
-            self.run = TestRun.from_xdist_test_runs(self)
+            self.run = TestRun.from_xdist_test_runs(self.workers_runs)
         self.load_archive()
         session.config.hook.pytest_ibutsu_before_shutdown(config=session.config, ibutsu=self)
         dump_to_archive(self)

--- a/src/pytest_ibutsu/sender.py
+++ b/src/pytest_ibutsu/sender.py
@@ -103,6 +103,11 @@ class IbutsuSender:
             self._make_call(self.run_api.update_run, id=run.id, run=run.to_dict())
         else:
             self._make_call(self.run_api.add_run, run=run.to_dict())
+        for filename, data in run._artifacts.items():
+            try:
+                self.upload_artifact(run.id, filename, data)
+            except (FileNotFoundError, IsADirectoryError):
+                continue
 
     def does_run_exist(self, run: TestRun) -> bool:
         return bool(self._make_call(self.run_api.get_run, id=run.id))
@@ -110,7 +115,10 @@ class IbutsuSender:
     def add_result(self, result: TestResult):
         self._make_call(self.result_api.add_result, result=result.to_dict())
         for filename, data in result._artifacts.items():
-            self.upload_artifact(result.id, filename, data)
+            try:
+                self.upload_artifact(result.id, filename, data)
+            except (FileNotFoundError, IsADirectoryError):
+                continue
 
     def upload_artifact(self, id_, filename, data, is_run=False):
         kwargs = {"run_id": id_} if is_run else {"result_id": id_}

--- a/tests/example_conftest.py
+++ b/tests/example_conftest.py
@@ -18,6 +18,11 @@ def pytest_collection_modifyitems(session, items, config):
         item._ibutsu["data"]["metadata"].update({"node_id": item.nodeid})
 
 
+def pytest_collection_finish(session):
+    ibutsu = session.config.stash[ibutsu_plugin_key]
+    ibutsu.run.attach_artifact("some_artifact.log", bytes("some_artifact", "utf8"))
+
+
 def pytest_exception_interact(node, call, report):
     node.config._ibutsu.upload_artifact_from_file(
         node._ibutsu["id"],

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2,6 +2,7 @@ import json
 import re
 import tarfile
 import uuid
+from collections import namedtuple
 from pathlib import Path
 from typing import Iterator
 from typing import List
@@ -39,22 +40,26 @@ def run_pytest(pytester: pytest.Pytester, args: List[str]) -> pytest.RunResult:
     return pytester.runpytest(*args)
 
 
+Param = namedtuple("Param", ["run_twice", "pytest_args"])
+
 PYTEST_XDIST_ARGS = [
-    pytest.param([], id="no-xdist"),
-    pytest.param(["-p", "xdist", "-n", "2"], id="xdist"),
+    pytest.param(Param(False, []), id="no-xdist-run-once"),
+    pytest.param(Param(False, ["-p", "xdist", "-n", "2"]), id="xdist-run-once"),
+    pytest.param(Param(True, []), id="no-xdist-run-twice"),
+    pytest.param(Param(True, ["-p", "xdist", "-n", "2"]), id="xdist-run-twice"),
 ]
 
 
 @pytest.fixture(params=PYTEST_XDIST_ARGS)
-def result(
-    pytester: pytest.Pytester, request: pytest.FixtureRequest, run_id: str
-) -> pytest.RunResult:
-    args = request.param + [
+def result(run_id: str, pytester: pytest.Pytester, request: pytest.FixtureRequest):
+    args = request.param.pytest_args + [
         "--ibutsu=archive",
         "--ibutsu-project=test_project",
         f"--ibutsu-run-id={run_id}",
         "example_test_to_report_to_ibutsu.py",
     ]
+    if request.param.run_twice:
+        run_pytest(pytester, args + ["-m", "some_marker"])
     return run_pytest(pytester, args)
 
 
@@ -125,7 +130,7 @@ def test_archive_content_results(archive: tarfile.TarFile, subtests, run_id: str
 @pytest.mark.parametrize(
     "artifact_name", ["legacy_exception", "actual_exception", "runtest_teardown", "runtest"]
 )
-def test_archive_artifacts(archive: tarfile.TarFile, subtests, artifact_name: str):
+def test_archive_artifacts(archive: tarfile.TarFile, subtests, artifact_name: str, run_id: str):
     run_json_tar_info = archive.extractfile(archive.getmembers()[1])
     run_json = json.load(run_json_tar_info)  # type: ignore
     members = [m for m in archive.getmembers() if m.isfile() and f"{artifact_name}.log" in m.name]
@@ -138,6 +143,8 @@ def test_archive_artifacts(archive: tarfile.TarFile, subtests, artifact_name: st
     assert (
         len(members) == run_json["summary"][collected_or_failures]
     ), f"There should be {artifact_name}.log for each {collected_or_failed} test"
+    run_artifact = archive.extractfile(f"{run_id}/some_artifact.log")
+    assert run_artifact.read() == bytes("some_artifact", "utf8")  # type: ignore
     for member in members:
         test_uuid = Path(member.name).parent.stem
         with subtests.test(name=member.name):
@@ -177,75 +184,3 @@ def test_collect(pytester: pytest.Pytester, pytest_collect_test: pytest.RunResul
     for path in pytester.path.glob("*"):
         archives += 1 if re.match(ARCHIVE_REGEX, path.name) else 0
     assert archives == 0, f"No archives should be created, got {archives}"
-
-
-@pytest.fixture(params=PYTEST_XDIST_ARGS)
-def pytest_run_twice(
-    run_id: str, pytester: pytest.Pytester, request: pytest.FixtureRequest
-) -> pytest.RunResult:
-    args = request.param + [
-        "--ibutsu=archive",
-        "--ibutsu-project=test_project",
-        f"--ibutsu-run-id={run_id}",
-        "example_test_to_report_to_ibutsu.py",
-        "-m",
-    ]
-    run_pytest(pytester, args + ["not some_marker"])
-    run_pytest(pytester, args + ["some_marker"])
-
-
-@pytest.mark.usefixtures("pytest_run_twice")
-def test_archives_count_after_two_runs(pytester: pytest.Pytester):
-    archives = 0
-    for path in pytester.path.glob("*"):
-        archives += 1 if re.match(ARCHIVE_REGEX, path.name) else 0
-    assert archives == 1, f"Expected exactly one archive file, got {archives}"
-
-
-@pytest.fixture
-def archive_after_two_runs(
-    pytest_run_twice, pytester: pytest.Pytester, run_id: str
-) -> Iterator[tarfile.TarFile]:
-    archive_name = f"{run_id}.tar.gz"
-    archive_path = pytester.path.joinpath(archive_name)
-    with tarfile.open(archive_path, "r:gz") as tar:
-        yield tar
-
-
-def test_archive_content_run_after_two_runs(archive_after_two_runs: tarfile.TarFile, run_id):
-    o = archive_after_two_runs.extractfile(f"{run_id}/run.json")
-    loaded = json.load(o)  # type: ignore
-    assert loaded["id"] == run_id
-    assert "start_time" in loaded
-    assert loaded["start_time"]
-    assert "duration" in loaded
-    assert loaded["duration"]
-    # remove fields that vary
-    del loaded["id"]
-    del loaded["start_time"]
-    del loaded["duration"]
-    assert loaded == expected_results.RUN
-
-
-def test_archive_content_results_after_two_runs(
-    archive_after_two_runs: tarfile.TarFile, subtests, run_id: str
-):
-    members = [
-        m for m in archive_after_two_runs.getmembers() if m.isfile() and "result.json" in m.name
-    ]
-    assert len(members) == 7
-    for member in members:
-        o = archive_after_two_runs.extractfile(member)
-        result = json.load(o)  # type: ignore
-        with subtests.test(name=result["test_id"]):
-            assert "id" in result
-            assert result["id"]
-            assert "start_time" in result
-            assert result["start_time"]
-            assert "duration" in result
-            assert result["duration"]
-            assert "run_id" in result
-            assert result["run_id"] == run_id
-            result = remove_varying_fields_from_result(result)
-            expected_result = expected_results.RESULTS[result["test_id"]]
-            assert result == expected_result


### PR DESCRIPTION
This PR adds the ability to attach artifacts to a test run. `TestRun` class exposes a new method `attach_artifact(self, name: str, content: Union[bytes, str]) -> None`. Artifacts are added to the archive and located near `run.json`, e.g.:

```
some_run_id
├── run.json
├── some_run_artifact
└── some_result_id
      ├── result.json
      └── some_result_artifact
```

Run artifacts are also uploaded to an Ibutsu server.