### PR TITLE
Add tests for client integration, support client v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "attrs",
   "boto3",
   "cattrs",
-  "ibutsu-client>=2.1,<3",
+  "ibutsu-client>3",
   "pytest",
 ]
 description = "A plugin to sent pytest results to an Ibutsu server"

--- a/tests/test_api_integration_scenarios.py
+++ b/tests/test_api_integration_scenarios.py
@@ -1,0 +1,585 @@
+"""Integration tests for API scenarios with ibutsu-client-python models.
+
+This module tests real-world API integration scenarios, ensuring that the
+pytest-ibutsu plugin properly interacts with the ibutsu-client-python API
+after the Pydantic v2 compatibility fixes.
+"""
+
+import json
+import uuid
+from datetime import datetime, UTC
+from unittest.mock import Mock, patch
+
+import pytest
+from ibutsu_client.models.result import Result as ClientResult
+from ibutsu_client.models.run import Run as ClientRun
+from ibutsu_client.exceptions import ApiException
+from urllib3.exceptions import NewConnectionError, ConnectTimeoutError
+
+from pytest_ibutsu.modeling import IbutsuTestResult, IbutsuTestRun
+from pytest_ibutsu.sender import IbutsuSender, send_data_to_ibutsu
+
+
+class TestAPIDataFlow:
+    """Test the complete data flow from pytest-ibutsu models to API calls."""
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_complete_result_submission_flow(self, mock_api_client):
+        """Test complete flow of submitting a test result to the API."""
+        sender = IbutsuSender("http://example.com/api", "test-token")
+
+        # Mock the API methods
+        sender.result_api.add_result = Mock()
+        sender._make_call = Mock()
+
+        # Create a comprehensive test result
+        result = IbutsuTestResult(
+            test_id="test_user_registration",
+            result="passed",
+            component="user-management",
+            env="production",
+            source="pytest-ibutsu",
+            run_id=str(uuid.uuid4()),
+            start_time=datetime.now(UTC).isoformat(),
+            duration=2.75,
+            metadata={
+                "markers": [{"name": "integration", "args": [], "kwargs": {}}],
+                "durations": {"setup": 0.25, "call": 2.0, "teardown": 0.5},
+                "statuses": {
+                    "setup": ("passed", False),
+                    "call": ("passed", False),
+                    "teardown": ("passed", False),
+                },
+                "user_properties": {"test_type": "integration", "priority": "high"},
+                "fspath": "tests/integration/test_user_management.py",
+                "node_id": "tests/integration/test_user_management.py::test_user_registration",
+            },
+            params={"username": "newuser", "email": "newuser@example.com"},
+        )
+
+        # Submit the result
+        sender.add_result(result)
+
+        # Verify _make_call was called with the correct data
+        sender._make_call.assert_called_once()
+        call_args = sender._make_call.call_args
+
+        # Verify the result dict can create a valid ClientResult
+        result_dict = call_args.kwargs["result"]
+        client_result = ClientResult(**result_dict)
+
+        assert client_result.test_id == "test_user_registration"
+        assert client_result.result == "passed"
+        assert client_result.component == "user-management"
+        assert client_result.duration == 2.75
+        assert "markers" in client_result.metadata
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_complete_run_submission_flow(self, mock_api_client):
+        """Test complete flow of submitting a test run to the API."""
+        sender = IbutsuSender("http://example.com/api", "test-token")
+
+        # Mock API methods
+        sender.run_api.get_run = Mock(return_value=None)  # Run doesn't exist
+        sender.run_api.add_run = Mock()
+        sender._make_call = Mock(
+            side_effect=[None, None]
+        )  # get_run returns None, add_run succeeds
+
+        # Create a comprehensive test run
+        run = IbutsuTestRun(
+            component="e2e-checkout-flow",
+            env="staging",
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=300.0,
+            metadata={
+                "jenkins": {
+                    "job_name": "nightly-e2e",
+                    "build_number": "1234",
+                    "build_url": "http://jenkins.example.com/job/nightly-e2e/1234",
+                },
+                "git": {
+                    "commit": "abc123def456",
+                    "branch": "feature/checkout-improvements",
+                },
+                "test_summary": {"total": 25, "passed": 23, "failed": 1, "skipped": 1},
+            },
+        )
+
+        # Submit the run
+        sender.add_or_update_run(run)
+
+        # Verify two calls were made: get_run and add_run
+        assert sender._make_call.call_count == 2
+
+        # Verify the run dict from the add_run call can create a valid ClientRun
+        add_run_call = [
+            call
+            for call in sender._make_call.call_args_list
+            if call.args[0] == sender.run_api.add_run
+        ][0]
+        run_dict = add_run_call.kwargs["run"]
+        client_run = ClientRun(**run_dict)
+
+        assert client_run.component == "e2e-checkout-flow"
+        assert client_run.env == "staging"
+        assert client_run.duration == 300.0
+        assert "jenkins" in client_run.metadata
+
+    @pytest.mark.parametrize(
+        "ibutsu_status,expected_client_status",
+        [
+            ("passed", "passed"),
+            ("failed", "failed"),
+            ("error", "error"),
+            ("skipped", "skipped"),
+            ("xfailed", "xfailed"),
+            ("xpassed", "xpassed"),
+        ],
+    )
+    def test_result_with_all_status_types(self, ibutsu_status, expected_client_status):
+        """Test results with different status types are handled correctly."""
+        result = IbutsuTestResult(test_id=f"test_{ibutsu_status}", result=ibutsu_status)
+
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        assert client_result.result == expected_client_status
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_artifact_upload_integration(self, mock_api_client):
+        """Test artifact upload integration with client models."""
+        sender = IbutsuSender("http://example.com/api")
+        sender.artifact_api.upload_artifact = Mock()
+        sender._make_call = Mock()
+
+        # Create result with artifact
+        result = IbutsuTestResult(test_id="test_with_artifacts")
+        result.attach_artifact("test_log.txt", b"Test execution log content")
+        result.attach_artifact("screenshot.png", b"PNG image data here")
+
+        # Upload artifacts
+        sender.upload_artifacts(result)
+
+        # Should make two calls for two artifacts
+        assert sender._make_call.call_count == 2
+
+    def test_large_metadata_serialization(self):
+        """Test that large metadata structures serialize properly for API calls."""
+        # Create metadata that might be problematic
+        large_metadata = {
+            "test_output": "A" * 1000,  # Large string
+            "nested_data": {
+                f"level_{i}": {
+                    "data": list(range(50)),
+                    "text": f"Text for level {i}" * 10,
+                }
+                for i in range(20)
+            },
+            "exception_details": {
+                "traceback": "\n".join([f"  File line {i}" for i in range(100)]),
+                "variables": {f"var_{i}": f"value_{i}" for i in range(50)},
+            },
+        }
+
+        result = IbutsuTestResult(
+            test_id="large_metadata_test", metadata=large_metadata
+        )
+
+        # Should serialize without issues
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        # Should be JSON serializable
+        json_str = client_result.model_dump_json()
+        assert len(json_str) > 5000  # Should be substantial
+
+        # Should be deserializable
+        parsed = json.loads(json_str)
+        assert parsed["test_id"] == "large_metadata_test"
+
+
+class TestAPIErrorHandling:
+    """Test error handling in API integration scenarios."""
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_api_exception_during_result_submission(self, mock_api_client):
+        """Test handling of API exceptions during result submission."""
+        sender = IbutsuSender("http://example.com/api")
+
+        # Mock the actual API method to raise an exception
+        sender.result_api.add_result = Mock(side_effect=ApiException("Server error"))
+
+        result = IbutsuTestResult(test_id="test_api_error")
+
+        # Should not raise exception (errors are logged and _make_call returns None)
+        sender.add_result(result)
+
+        # Error should be tracked
+        assert sender._has_server_error is True
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_api_call_with_invalid_authentication_token(self, mock_api_client):
+        """Test handling of API calls with invalid or expired authentication tokens."""
+        sender = IbutsuSender("http://example.com/api", "invalid-token")
+
+        # Mock the API method to raise an authentication exception
+        auth_error = ApiException(status=401, reason="Unauthorized")
+        auth_error.body = '{"detail": "Invalid authentication credentials"}'
+        sender.result_api.add_result = Mock(side_effect=auth_error)
+
+        result = IbutsuTestResult(test_id="test_auth_error")
+
+        # Should not raise exception (errors are logged and _make_call returns None)
+        sender.add_result(result)
+
+        # Error should be tracked and reported correctly
+        assert sender._has_server_error is True
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_network_error_during_run_submission(self, mock_api_client):
+        """Test handling of network errors during run submission."""
+        sender = IbutsuSender("http://example.com/api")
+
+        # Mock both get_run and add_run to raise network errors
+        # get_run is called with hide_exception=True, so it won't set error flag
+        # add_run is called with hide_exception=False, so it will set error flag
+        sender.run_api.get_run = Mock(
+            side_effect=NewConnectionError(Mock(), "Connection failed")
+        )
+        sender.run_api.add_run = Mock(
+            side_effect=NewConnectionError(Mock(), "Connection failed")
+        )
+
+        run = IbutsuTestRun(component="network_test")
+
+        # Should not raise exception
+        sender.add_or_update_run(run)
+
+        # Error should be tracked from the add_run call (not hidden)
+        assert sender._has_server_error is True
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_timeout_during_artifact_upload(self, mock_api_client):
+        """Test handling of timeouts during artifact upload."""
+        sender = IbutsuSender("http://example.com/api")
+        sender._make_call = Mock(side_effect=ConnectTimeoutError("Upload timeout"))
+
+        result = IbutsuTestResult(test_id="timeout_test")
+        result.attach_artifact("large_file.log", b"x" * 1000000)  # 1MB
+
+        # Should handle timeout gracefully
+        sender.upload_artifacts(result)
+
+        # Should attempt upload despite timeout
+        sender._make_call.assert_called()
+
+    def test_invalid_data_validation_before_api_call(self):
+        """Test that invalid data is caught before making API calls."""
+        # Create result with data that would be invalid for ClientResult
+        result = IbutsuTestResult(test_id="validation_test")
+        result.result = "invalid_status"  # This would fail ClientResult validation
+
+        result_dict = result.to_dict()
+
+        # Should fail when trying to create ClientResult
+        with pytest.raises(Exception):  # ValidationError or similar
+            ClientResult(**result_dict)
+
+
+class TestConcurrentOperations:
+    """Test concurrent operations and async scenarios."""
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_multiple_results_submission(self, mock_api_client):
+        """Test submitting multiple results in sequence."""
+        sender = IbutsuSender("http://example.com/api")
+        sender._make_call = Mock()
+
+        results = [
+            IbutsuTestResult(test_id=f"test_{i}", result="passed") for i in range(5)
+        ]
+
+        # Submit all results
+        for result in results:
+            sender.add_result(result)
+
+        # Should make 5 API calls
+        assert sender._make_call.call_count == 5
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_run_and_results_submission_sequence(self, mock_api_client):
+        """Test the typical sequence of run creation followed by result submissions."""
+        sender = IbutsuSender("http://example.com/api")
+        sender._make_call = Mock(return_value=None)
+
+        # Create run and results
+        run = IbutsuTestRun(component="sequence_test")
+        results = [
+            IbutsuTestResult(test_id=f"test_{i}", run_id=run.id) for i in range(3)
+        ]
+
+        # Submit run first
+        sender.add_or_update_run(run)
+
+        # Then submit results
+        for result in results:
+            sender.add_result(result)
+
+        # Should make 5 calls total: 2 for run (get + add), 3 for results
+        assert sender._make_call.call_count == 5
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_async_request_handling(self, mock_api_client):
+        """Test handling of async requests."""
+        sender = IbutsuSender("http://example.com/api")
+
+        # Mock async result
+        mock_async_result = Mock()
+        mock_async_result.ready.return_value = False
+
+        # Mock the actual API method to return the async result
+        sender.result_api.add_result = Mock(return_value=mock_async_result)
+
+        result = IbutsuTestResult(test_id="async_test")
+
+        # Make async call through _make_call
+        response = sender._make_call(
+            sender.result_api.add_result, result=result.to_dict(), async_req=True
+        )
+
+        # Should cache the async result
+        assert response == mock_async_result
+        assert mock_async_result in sender._sender_cache
+
+
+class TestDataConsistency:
+    """Test data consistency between models and API calls."""
+
+    def test_uuid_consistency_across_models(self):
+        """Test that UUIDs remain consistent across model conversions."""
+        # Create UUIDs
+        result_id = uuid.uuid4()
+        run_id = uuid.uuid4()
+
+        # Create IbutsuTestResult
+        ibutsu_result = IbutsuTestResult(
+            test_id="uuid_consistency_test", id=str(result_id), run_id=str(run_id)
+        )
+
+        # Convert to dict and back to ClientResult
+        result_dict = ibutsu_result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        # UUIDs should be preserved
+        assert client_result.id == result_id
+        assert client_result.run_id == run_id
+
+        # Should serialize and deserialize consistently
+        json_str = client_result.model_dump_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["id"] == str(result_id)
+        assert parsed["run_id"] == str(run_id)
+
+    def test_timestamp_consistency(self):
+        """Test that timestamps remain consistent across conversions."""
+        timestamp = datetime.now(UTC).isoformat()
+
+        result = IbutsuTestResult(test_id="timestamp_test", start_time=timestamp)
+
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        assert client_result.start_time == timestamp
+
+    def test_duration_precision_consistency(self):
+        """Test that duration precision is maintained."""
+        precise_duration = 123.456789
+
+        result = IbutsuTestResult(test_id="duration_test", duration=precise_duration)
+
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        assert client_result.duration == precise_duration
+
+    def test_metadata_structure_consistency(self):
+        """Test that complex metadata structures remain consistent."""
+        complex_metadata = {
+            "nested": {
+                "level1": {
+                    "level2": ["item1", "item2", "item3"],
+                    "numbers": [1, 2, 3.14159],
+                    "boolean": True,
+                }
+            },
+            "unicode": "Testing: ñáéíóú 中文 🚀",
+            "null_value": None,
+            "empty_dict": {},
+            "empty_list": [],
+        }
+
+        result = IbutsuTestResult(
+            test_id="metadata_consistency_test", metadata=complex_metadata
+        )
+
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        # Deep comparison of metadata
+        assert client_result.metadata["nested"]["level1"]["level2"] == [
+            "item1",
+            "item2",
+            "item3",
+        ]
+        assert client_result.metadata["nested"]["level1"]["numbers"] == [1, 2, 3.14159]
+        assert client_result.metadata["unicode"] == "Testing: ñáéíóú 中文 🚀"
+        assert client_result.metadata["null_value"] is None
+
+
+class TestFullIntegrationScenarios:
+    """Test full integration scenarios mimicking real pytest-ibutsu usage."""
+
+    @patch("pytest_ibutsu.sender.IbutsuSender.from_ibutsu_plugin")
+    def test_complete_test_session_flow(self, mock_from_plugin):
+        """Test a complete test session flow with multiple results."""
+        # Mock sender
+        mock_sender = Mock()
+        mock_sender._has_server_error = False
+        mock_sender.frontend_url = "http://frontend.example.com"
+        mock_from_plugin.return_value = mock_sender
+
+        # Mock plugin with realistic data
+        mock_plugin = Mock()
+
+        # Create realistic test run
+        run = IbutsuTestRun(
+            component="payment-service", env="staging", source="pytest-ibutsu"
+        )
+        run.start_timer()
+        run.metadata.update(
+            {
+                "jenkins": {"job_name": "payment-service-tests", "build_number": "456"},
+                "git": {"commit": "abc123", "branch": "develop"},
+            }
+        )
+        mock_plugin.run = run
+
+        # Create realistic test results
+        test_results = {
+            "test_process_payment": IbutsuTestResult(
+                test_id="test_process_payment",
+                result="passed",
+                component="payment-service",
+                env="staging",
+                duration=1.5,
+                metadata={
+                    "markers": [{"name": "integration", "args": [], "kwargs": {}}],
+                    "statuses": {"call": ("passed", False)},
+                },
+            ),
+            "test_invalid_card": IbutsuTestResult(
+                test_id="test_invalid_card",
+                result="failed",
+                component="payment-service",
+                env="staging",
+                duration=0.8,
+                metadata={
+                    "exception_name": "ValidationError",
+                    "statuses": {"call": ("failed", False)},
+                },
+            ),
+            "test_expired_card": IbutsuTestResult(
+                test_id="test_expired_card",
+                result="skipped",
+                component="payment-service",
+                env="staging",
+                duration=0.0,
+                metadata={
+                    "skip_reason": "Test card expired",
+                    "statuses": {"setup": ("skipped", False)},
+                },
+            ),
+        }
+        mock_plugin.results = test_results
+        mock_plugin.summary_info = {"errors": []}
+
+        # Run the complete flow
+        send_data_to_ibutsu(mock_plugin)
+
+        # Verify all operations were performed
+        assert mock_sender.add_or_update_run.call_count == 2  # Start and end
+        assert mock_sender.add_result.call_count == 3  # Three test results
+        assert mock_sender.upload_artifacts.call_count == 4  # Run + 3 results
+
+        # Verify all results can be converted to valid client models
+        for result in test_results.values():
+            result_dict = result.to_dict()
+            client_result = ClientResult(**result_dict)
+            assert client_result.test_id is not None
+
+    @pytest.mark.parametrize(
+        "username,password,expected_result",
+        [
+            ("user1", "password1", "passed"),
+            ("user2", "password2", "passed"),
+            ("invalid_user", "wrong_pass", "failed"),
+        ],
+    )
+    def test_parameterized_test_results_integration(
+        self, username, password, expected_result
+    ):
+        """Test integration with parameterized test results."""
+        result = IbutsuTestResult(
+            test_id=f"test_login[{username}-{password}]",
+            result=expected_result,
+            component="authentication",
+            params={"username": username, "password": password},
+            metadata={
+                "markers": [
+                    {
+                        "name": "parametrize",
+                        "args": ["username,password", [(username, password)]],
+                        "kwargs": {},
+                    }
+                ],
+                "node_id": f"tests/test_auth.py::test_login[{username}-{password}]",
+            },
+        )
+
+        # Should convert to valid client model
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+        assert "[" in client_result.test_id  # Contains parameter info
+        assert client_result.params["username"] in client_result.test_id
+
+    def test_xdist_parallel_execution_integration(self):
+        """Test integration with pytest-xdist parallel execution."""
+        # Simulate multiple worker runs that need to be merged
+        worker_runs = []
+        for worker_id in ["gw0", "gw1", "gw2"]:
+            run = IbutsuTestRun(
+                component="parallel-tests", env="ci", source="pytest-ibutsu"
+            )
+            run.metadata["worker_id"] = worker_id
+
+            # Add some results to each worker
+            for i in range(2):
+                result = IbutsuTestResult(
+                    test_id=f"test_{worker_id}_{i}", result="passed", run_id=run.id
+                )
+                run._results.append(result)
+
+            worker_runs.append(run)
+
+        # Merge runs (as would happen in xdist scenario)
+        merged_run = IbutsuTestRun.from_xdist_test_runs(worker_runs)
+
+        # Should convert to valid client model
+        run_dict = merged_run.to_dict()
+        client_run = ClientRun(**run_dict)
+
+        assert client_run.component == "parallel-tests"
+        assert len(merged_run._results) == 6  # 3 workers × 2 tests each

--- a/tests/test_client_model_integration.py
+++ b/tests/test_client_model_integration.py
@@ -1,0 +1,662 @@
+"""Integration tests for ibutsu-client-python model usage and validation.
+
+This module tests the integration between pytest-ibutsu and the ibutsu-client-python
+models, ensuring proper serialization, validation, and API compatibility after
+the Pydantic v2 compatibility fixes.
+"""
+
+import json
+import uuid
+from datetime import datetime, UTC
+from unittest.mock import Mock, patch
+
+import pytest
+from ibutsu_client.models.result import Result as ClientResult
+from ibutsu_client.models.run import Run as ClientRun
+from ibutsu_client.api.result_api import ResultApi
+from ibutsu_client.api.run_api import RunApi
+from pydantic import ValidationError
+
+from pytest_ibutsu.modeling import IbutsuTestResult, IbutsuTestRun
+from pytest_ibutsu.sender import IbutsuSender
+
+
+class TestClientModelCompatibility:
+    """Test compatibility between pytest-ibutsu models and ibutsu-client models."""
+
+    def test_result_model_instantiation_with_valid_data(self):
+        """Test that ClientResult can be instantiated with valid data."""
+        # Test data that should be accepted by the Result model
+        valid_data = {
+            "test_id": "test_function_123",
+            "result": "passed",
+            "component": "auth",
+            "env": "production",
+            "source": "pytest-ibutsu",
+            "start_time": datetime.now(UTC).isoformat(),
+            "duration": 2.5,
+        }
+
+        # Should not raise any validation errors
+        result = ClientResult(**valid_data)
+
+        assert result.test_id == "test_function_123"
+        assert result.result == "passed"
+        assert result.component == "auth"
+        assert result.env == "production"
+        assert result.source == "pytest-ibutsu"
+        assert result.duration == 2.5
+
+    @pytest.mark.parametrize(
+        "result_value",
+        [
+            "passed",
+            "failed",
+            "error",
+            "skipped",
+            "xpassed",
+            "xfailed",
+            "manual",
+            "blocked",
+        ],
+    )
+    def test_result_model_field_validation(self, result_value):
+        """Test that Result model properly validates the result field enum."""
+        # Should not raise validation error
+        result = ClientResult(test_id="test_123", result=result_value)
+        assert result.result == result_value
+
+    @pytest.mark.parametrize(
+        "invalid_case_value",
+        [
+            "PASSED",
+            "Failed",
+            "ERROR",
+            "Skipped",
+            "XPASSED",
+            "XFailed",
+            "MANUAL",
+            "Blocked",
+        ],
+    )
+    def test_result_enum_case_sensitivity(self, invalid_case_value):
+        """Test that Result model validates case sensitivity in result enum values."""
+        with pytest.raises(ValidationError) as exc_info:
+            ClientResult(test_id="test_123", result=invalid_case_value)
+
+        error_str = str(exc_info.value)
+        assert "must be one of enum values" in error_str
+
+    def test_result_model_invalid_result_enum(self):
+        """Test that Result model rejects invalid result enum values."""
+        with pytest.raises(ValidationError) as exc_info:
+            ClientResult(test_id="test_123", result="invalid_status")
+
+        # Should mention that it's not one of the valid enum values
+        error_str = str(exc_info.value)
+        assert "must be one of enum values" in error_str
+        assert "passed" in error_str
+        assert "failed" in error_str
+
+    def test_run_model_instantiation_with_valid_data(self):
+        """Test that ClientRun can be instantiated with valid data."""
+        valid_data = {
+            "component": "authentication",
+            "env": "staging",
+            "source": "pytest-ibutsu",
+            "start_time": datetime.now(UTC).isoformat(),
+            "duration": 120.5,
+            "metadata": {"build": "123", "branch": "main"},
+        }
+
+        # Should not raise any validation errors
+        run = ClientRun(**valid_data)
+
+        assert run.component == "authentication"
+        assert run.env == "staging"
+        assert run.source == "pytest-ibutsu"
+        assert run.duration == 120.5
+        assert run.metadata == {"build": "123", "branch": "main"}
+
+    def test_uuid_field_handling(self):
+        """Test that UUID fields are properly handled in client models."""
+        # Test with string UUID
+        uuid_str = str(uuid.uuid4())
+        result = ClientResult(test_id="test_123", id=uuid_str)
+
+        # The id should be accepted and stored
+        assert str(result.id) == uuid_str
+
+        # Test with actual UUID object
+        uuid_obj = uuid.uuid4()
+        result2 = ClientResult(test_id="test_123", id=uuid_obj)
+        assert result2.id == uuid_obj
+
+        # Test with None (should be allowed for optional UUID fields)
+        result3 = ClientResult(test_id="test_123", run_id=None, project_id=None)
+        assert result3.run_id is None
+        assert result3.project_id is None
+
+    @pytest.mark.parametrize(
+        "invalid_uuid",
+        [
+            "not-a-uuid",
+            "12345678-1234-1234-1234",  # Too short
+            "12345678-1234-1234-1234-12345678901234",  # Too long
+            "",
+            "random-string",
+            123,  # Not a string
+            [],  # Not a string
+        ],
+    )
+    def test_uuid_field_invalid_formats(self, invalid_uuid):
+        """Test that invalid UUID formats and types are properly rejected."""
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="test_123", id=invalid_uuid)
+
+    @pytest.mark.parametrize(
+        "model_class,field_name",
+        [
+            (ClientResult, "id"),
+            (ClientResult, "run_id"),
+            (ClientResult, "project_id"),
+            (ClientRun, "id"),
+            (ClientRun, "project_id"),
+        ],
+    )
+    def test_uuid_field_validation(self, model_class, field_name):
+        """Test UUID field validation for various models and fields."""
+        # Valid UUID should work
+        valid_uuid = str(uuid.uuid4())
+        kwargs = {"test_id": "test"} if model_class == ClientResult else {}
+        kwargs[field_name] = valid_uuid
+
+        instance = model_class(**kwargs)
+        assert getattr(instance, field_name) is not None
+
+    def test_model_json_serialization(self):
+        """Test that client models can be serialized to JSON."""
+        # Create a Result with various data types
+        result = ClientResult(
+            test_id="test_function",
+            result="passed",
+            component="auth",
+            env="production",
+            source="pytest-ibutsu",
+            id=uuid.uuid4(),
+            run_id=uuid.uuid4(),
+            project_id=uuid.uuid4(),
+            start_time=datetime.now(UTC).isoformat(),
+            duration=1.5,
+            metadata={"key": "value", "nested": {"data": [1, 2, 3]}},
+            params={"param1": "value1", "param2": 42},
+        )
+
+        # Should be able to serialize to JSON
+        json_str = result.model_dump_json()
+        assert isinstance(json_str, str)
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed["test_id"] == "test_function"
+        assert parsed["result"] == "passed"
+        assert parsed["metadata"]["key"] == "value"
+
+    def test_model_dict_conversion(self):
+        """Test that client models can be converted to dictionaries."""
+        run = ClientRun(
+            component="web",
+            env="test",
+            source="pytest-ibutsu",
+            id=uuid.uuid4(),
+            metadata={"version": "1.0", "commit": "abc123"},
+        )
+
+        # Convert to dict
+        run_dict = run.model_dump()
+
+        assert isinstance(run_dict, dict)
+        assert run_dict["component"] == "web"
+        assert run_dict["env"] == "test"
+        assert run_dict["source"] == "pytest-ibutsu"
+        assert "id" in run_dict
+        assert run_dict["metadata"]["version"] == "1.0"
+
+
+class TestIbutsuTestResultToClientResultConversion:
+    """Test conversion from IbutsuTestResult to client Result model."""
+
+    def test_ibutsu_result_to_client_result_conversion(self):
+        """Test converting IbutsuTestResult to client Result model."""
+        # Create an IbutsuTestResult
+        ibutsu_result = IbutsuTestResult(
+            test_id="test_login_success",
+            result="passed",
+            component="auth",
+            env="staging",
+            source="pytest-ibutsu",
+            duration=1.25,
+            metadata={"browser": "chrome", "version": "90.0"},
+            params={"username": "testuser", "password": "hidden"},
+        )
+
+        # Convert to dict (as would be done in sender)
+        result_dict = ibutsu_result.to_dict()
+
+        # Should be able to create client Result from this dict
+        client_result = ClientResult(**result_dict)
+
+        assert client_result.test_id == "test_login_success"
+        assert client_result.result == "passed"
+        assert client_result.component == "auth"
+        assert client_result.env == "staging"
+        assert client_result.source == "pytest-ibutsu"
+        assert client_result.duration == 1.25
+
+    def test_ibutsu_result_with_invalid_result_status(self):
+        """Test that invalid result status is caught when converting to client model."""
+        # Create IbutsuTestResult with invalid status (this shouldn't happen in practice)
+        ibutsu_result = IbutsuTestResult(test_id="test_1")
+        ibutsu_result.result = "invalid_status"  # Manually set invalid status
+
+        result_dict = ibutsu_result.to_dict()
+
+        # Client model should reject this
+        with pytest.raises(ValidationError):
+            ClientResult(**result_dict)
+
+    def test_ibutsu_result_with_complex_metadata(self):
+        """Test IbutsuTestResult with complex metadata converts properly."""
+        ibutsu_result = IbutsuTestResult(
+            test_id="complex_test",
+            metadata={
+                "markers": [{"name": "slow", "args": [], "kwargs": {}}],
+                "durations": {"setup": 0.1, "call": 2.0, "teardown": 0.05},
+                "statuses": {"setup": ("passed", False), "call": ("passed", False)},
+                "user_properties": {"custom_key": "custom_value"},
+                "fspath": "tests/test_auth.py",
+                "node_id": "tests/test_auth.py::test_login_success[user1]",
+            },
+        )
+
+        result_dict = ibutsu_result.to_dict()
+
+        # Should be able to create client model even with complex metadata
+        client_result = ClientResult(**result_dict)
+        assert client_result.metadata is not None
+        assert "markers" in client_result.metadata
+        assert "durations" in client_result.metadata
+
+    def test_uuid_field_consistency(self):
+        """Test that UUID fields are consistent between models."""
+        test_uuid = uuid.uuid4()
+        run_uuid = uuid.uuid4()
+
+        ibutsu_result = IbutsuTestResult(
+            test_id="uuid_test", id=str(test_uuid), run_id=str(run_uuid)
+        )
+
+        result_dict = ibutsu_result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        # UUIDs should be preserved
+        assert str(client_result.id) == str(test_uuid)
+        assert str(client_result.run_id) == str(run_uuid)
+
+
+class TestIbutsuTestRunToClientRunConversion:
+    """Test conversion from IbutsuTestRun to client Run model."""
+
+    def test_ibutsu_run_to_client_run_conversion(self):
+        """Test converting IbutsuTestRun to client Run model."""
+        ibutsu_run = IbutsuTestRun(
+            component="api-tests",
+            env="production",
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=45.5,
+            metadata={"build_id": "build-123", "commit_sha": "abc123def"},
+        )
+
+        run_dict = ibutsu_run.to_dict()
+
+        # Should be able to create client Run from this dict
+        client_run = ClientRun(**run_dict)
+
+        assert client_run.component == "api-tests"
+        assert client_run.env == "production"
+        assert client_run.source == "pytest-ibutsu"
+        assert client_run.duration == 45.5
+
+    def test_ibutsu_run_with_jenkins_metadata(self):
+        """Test IbutsuTestRun with Jenkins metadata converts properly."""
+        ibutsu_run = IbutsuTestRun()
+        ibutsu_run.metadata["jenkins"] = {
+            "job_name": "test-job",
+            "build_number": "123",
+            "build_url": "http://jenkins.example.com/job/test-job/123",
+        }
+
+        run_dict = ibutsu_run.to_dict()
+        client_run = ClientRun(**run_dict)
+
+        assert "jenkins" in client_run.metadata
+        assert client_run.metadata["jenkins"]["job_name"] == "test-job"
+        assert client_run.metadata["jenkins"]["build_number"] == "123"
+
+
+class TestSenderModelIntegration:
+    """Test IbutsuSender integration with client models."""
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_sender_add_result_with_client_model_data(self, mock_api_client):
+        """Test that sender properly sends IbutsuTestResult data to client API."""
+        sender = IbutsuSender("http://example.com/api")
+
+        # Mock the result API
+        mock_result_api = Mock(spec=ResultApi)
+        sender.result_api = mock_result_api
+        sender._make_call = Mock()
+
+        # Create a test result
+        result = IbutsuTestResult(
+            test_id="test_api_endpoint",
+            result="passed",
+            component="api",
+            env="test",
+            duration=0.5,
+        )
+
+        # Call add_result
+        sender.add_result(result)
+
+        # Verify _make_call was called with correct arguments
+        sender._make_call.assert_called_once_with(
+            sender.result_api.add_result, result=result.to_dict()
+        )
+
+        # Verify the dict can be used to create a valid client Result
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+        assert client_result.test_id == "test_api_endpoint"
+        assert client_result.result == "passed"
+
+    @patch("pytest_ibutsu.sender.ApiClient")
+    def test_sender_add_run_with_client_model_data(self, mock_api_client):
+        """Test that sender properly sends IbutsuTestRun data to client API."""
+        sender = IbutsuSender("http://example.com/api")
+
+        # Mock the run API
+        mock_run_api = Mock(spec=RunApi)
+        sender.run_api = mock_run_api
+        sender._make_call = Mock(return_value=None)  # Simulate new run
+
+        # Create a test run
+        run = IbutsuTestRun(
+            component="web-tests", env="staging", source="pytest-ibutsu"
+        )
+
+        # Call add_or_update_run
+        sender.add_or_update_run(run)
+
+        # Should make two calls: get_run (returns None) and add_run
+        assert sender._make_call.call_count == 2
+
+        # Verify the run dict can be used to create a valid client Run
+        run_dict = run.to_dict()
+        client_run = ClientRun(**run_dict)
+        assert client_run.component == "web-tests"
+        assert client_run.env == "staging"
+
+    def test_result_serialization_for_api_calls(self):
+        """Test that result serialization produces API-compatible data."""
+        # Create a result with all possible fields
+        result = IbutsuTestResult(
+            test_id="comprehensive_test",
+            result="failed",
+            component="database",
+            env="production",
+            source="pytest-ibutsu",
+            run_id=str(uuid.uuid4()),
+            start_time=datetime.now(UTC).isoformat(),
+            duration=10.5,
+            metadata={
+                "exception_name": "AssertionError",
+                "short_tb": "AssertionError: Values don't match",
+                "markers": [{"name": "database", "args": [], "kwargs": {}}],
+                "durations": {"setup": 0.1, "call": 10.0, "teardown": 0.4},
+                "statuses": {"setup": ("passed", False), "call": ("failed", False)},
+                "classification": "test_failure",
+            },
+            params={"table_name": "users", "record_count": 1000},
+        )
+
+        # Serialize for API
+        result_dict = result.to_dict()
+
+        # Should be JSON serializable
+        json_str = json.dumps(result_dict)
+        assert json_str != ""
+
+        # Should be valid for client model
+        client_result = ClientResult(**result_dict)
+        assert client_result.test_id == "comprehensive_test"
+        assert client_result.result == "failed"
+        assert client_result.metadata["exception_name"] == "AssertionError"
+
+    def test_run_serialization_for_api_calls(self):
+        """Test that run serialization produces API-compatible data."""
+        # Create a run with comprehensive data
+        run = IbutsuTestRun(
+            component="integration-tests",
+            env="production",
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=300.0,
+            metadata={
+                "jenkins": {
+                    "job_name": "nightly-tests",
+                    "build_number": "456",
+                    "build_url": "http://jenkins.example.com/job/nightly-tests/456",
+                },
+                "env_id": "prod-env-123",
+                "git_commit": "def456abc",
+                "git_branch": "release/v2.0",
+            },
+        )
+
+        # Serialize for API
+        run_dict = run.to_dict()
+
+        # Should be JSON serializable
+        json_str = json.dumps(run_dict)
+        assert json_str != ""
+
+        # Should be valid for client model
+        client_run = ClientRun(**run_dict)
+        assert client_run.component == "integration-tests"
+        assert client_run.env == "production"
+        assert client_run.metadata["jenkins"]["job_name"] == "nightly-tests"
+
+
+class TestModelFieldCompatibility:
+    """Test field compatibility between pytest-ibutsu and client models."""
+
+    def test_result_field_mapping_completeness(self):
+        """Test that all IbutsuTestResult fields map to ClientResult fields."""
+        # Create IbutsuTestResult with all public fields
+        result = IbutsuTestResult(
+            test_id="field_mapping_test",
+            component="auth",
+            env="test",
+            result="passed",
+            id=str(uuid.uuid4()),
+            metadata={"key": "value"},
+            params={"param": "value"},
+            run_id=str(uuid.uuid4()),
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=1.0,
+        )
+
+        result_dict = result.to_dict()
+
+        # Should not have private fields
+        assert not any(key.startswith("_") for key in result_dict.keys())
+
+        # All public fields should be present and mappable to ClientResult
+        client_result = ClientResult(**result_dict)
+
+        # Verify key fields are mapped correctly
+        assert client_result.test_id == result.test_id
+        assert client_result.component == result.component
+        assert client_result.env == result.env
+        assert client_result.result == result.result
+        assert str(client_result.id) == result.id
+        assert client_result.metadata == result.metadata
+        assert client_result.params == result.params
+        assert client_result.source == result.source
+        assert client_result.duration == result.duration
+
+    def test_run_field_mapping_completeness(self):
+        """Test that all IbutsuTestRun fields map to ClientRun fields."""
+        # Create IbutsuTestRun with all public fields
+        run = IbutsuTestRun(
+            component="api",
+            env="staging",
+            id=str(uuid.uuid4()),
+            metadata={"build": "123"},
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=60.0,
+        )
+
+        run_dict = run.to_dict()
+
+        # Should not have private fields
+        assert not any(key.startswith("_") for key in run_dict.keys())
+
+        # All public fields should be mappable to ClientRun
+        client_run = ClientRun(**run_dict)
+
+        # Verify key fields are mapped correctly
+        assert client_run.component == run.component
+        assert client_run.env == run.env
+        assert str(client_run.id) == run.id
+        assert client_run.metadata == run.metadata
+        assert client_run.source == run.source
+        assert client_run.duration == run.duration
+
+    def test_optional_fields_handling(self):
+        """Test that optional fields are properly handled in both models."""
+        # Create minimal result
+        result = IbutsuTestResult(test_id="minimal_test")
+        result_dict = result.to_dict()
+
+        # Should create valid client result with defaults
+        client_result = ClientResult(**result_dict)
+        assert client_result.test_id == "minimal_test"
+        assert client_result.result == "passed"  # default
+        assert client_result.source == "local"  # default
+
+        # Create minimal run
+        run = IbutsuTestRun()
+        run_dict = run.to_dict()
+
+        # Should create valid client run with defaults
+        client_run = ClientRun(**run_dict)
+        assert client_run.component is None  # optional field
+        assert client_run.env is None  # optional field
+
+
+class TestErrorHandling:
+    """Test error handling in model integration scenarios."""
+
+    def test_api_exception_with_invalid_data(self):
+        """Test handling of API exceptions when sending invalid data."""
+        # This simulates what would happen if somehow invalid data
+        # made it through to the client API
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="test", result="invalid_result_value")
+
+    def test_malformed_uuid_handling(self):
+        """Test handling of malformed UUID strings."""
+        # Invalid UUID string should raise ValidationError
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="test", id="not-a-uuid")
+
+    def test_missing_required_fields(self):
+        """Test handling of missing required fields."""
+        # ClientResult allows None for test_id (it's optional in this version)
+        result = ClientResult(result="passed")  # Missing test_id is allowed
+        assert result.test_id is None
+        assert result.result == "passed"
+
+    def test_type_validation_errors(self):
+        """Test type validation in client models."""
+        # Duration should be numeric
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="test", duration="not_a_number")
+
+        # Metadata should be dict if provided
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="test", metadata="not_a_dict")
+
+    @pytest.mark.parametrize(
+        "invalid_result", ["unknown", "custom_status", "", 123, ["passed"]]
+    )
+    def test_result_enum_validation_comprehensive(self, invalid_result):
+        """Test comprehensive result enum validation."""
+        with pytest.raises((ValidationError, TypeError)):
+            ClientResult(test_id="test", result=invalid_result)
+
+    def test_result_none_value_allowed(self):
+        """Test that None is allowed for result field."""
+        # None is allowed as a valid value
+        result = ClientResult(test_id="test", result=None)
+        assert result.result is None
+
+
+class TestBackwardsCompatibility:
+    """Test backwards compatibility with existing pytest-ibutsu usage."""
+
+    def test_existing_result_creation_still_works(self):
+        """Test that existing ways of creating results still work."""
+        # This simulates the typical way results are created in pytest-ibutsu
+        result = IbutsuTestResult(test_id="backwards_compat_test")
+        result.result = "passed"
+        result.component = "legacy_component"
+        result.duration = 2.5
+        result.metadata = {"legacy": True}
+
+        # Should still convert to client model successfully
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        assert client_result.test_id == "backwards_compat_test"
+        assert client_result.result == "passed"
+        assert client_result.component == "legacy_component"
+
+    def test_metadata_serialization_compatibility(self):
+        """Test that complex metadata still serializes correctly."""
+        # Test the type of complex metadata that pytest-ibutsu typically creates
+        result = IbutsuTestResult(test_id="metadata_compat_test")
+        result.metadata = {
+            "statuses": {"setup": ("passed", False), "call": ("passed", False)},
+            "durations": {"setup": 0.1, "call": 1.0, "teardown": 0.05},
+            "markers": [
+                {"name": "slow", "args": [], "kwargs": {}},
+                {"name": "parametrize", "args": ["input", "expected"], "kwargs": {}},
+            ],
+            "user_properties": [("custom_prop", "custom_value")],
+            "fspath": "tests/test_example.py",
+            "node_id": "tests/test_example.py::test_function[param1]",
+        }
+
+        # Should serialize and be accepted by client model
+        result_dict = result.to_dict()
+        client_result = ClientResult(**result_dict)
+
+        assert "statuses" in client_result.metadata
+        assert "durations" in client_result.metadata
+        assert "markers" in client_result.metadata

--- a/tests/test_pydantic_v2_validation.py
+++ b/tests/test_pydantic_v2_validation.py
@@ -1,0 +1,624 @@
+"""Tests specifically for Pydantic v2 compatibility and field validation.
+
+This module tests the fixes applied for Pydantic v2 compatibility, ensuring that
+field validators work correctly and that the UUID import consolidation doesn't
+break functionality.
+"""
+
+import json
+import uuid
+from datetime import datetime, UTC
+
+import pytest
+from pydantic import ValidationError
+from ibutsu_client.models.result import Result as ClientResult
+from ibutsu_client.models.run import Run as ClientRun
+
+
+class TestPydanticV2FieldValidators:
+    """Test that Pydantic v2 field validators work correctly."""
+
+    @pytest.mark.parametrize(
+        "result_value",
+        [
+            "passed",
+            "failed",
+            "error",
+            "skipped",
+            "xpassed",
+            "xfailed",
+            "manual",
+            "blocked",
+        ],
+    )
+    def test_result_enum_validator_accepts_valid_values(self, result_value):
+        """Test that the result field validator accepts all valid enum values."""
+        # Should not raise ValidationError
+        result = ClientResult(test_id="test_123", result=result_value)
+        assert result.result == result_value
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "unknown",
+            "pending",
+            "running",
+            "cancelled",
+            "timeout",
+            "abort",
+            "",
+            123,
+            [],
+        ],
+    )
+    def test_result_enum_validator_rejects_invalid_values(self, invalid_value):
+        """Test that the result field validator rejects invalid enum values."""
+        with pytest.raises((ValidationError, TypeError)):
+            ClientResult(test_id="test_123", result=invalid_value)
+
+    def test_result_none_value_is_allowed(self):
+        """Test that None is allowed for result field."""
+        # None is a special case that's allowed
+        result = ClientResult(test_id="test_123", result=None)
+        assert result.result is None
+
+    def test_result_enum_validator_error_message(self):
+        """Test that the result field validator provides helpful error messages."""
+        with pytest.raises(ValidationError) as exc_info:
+            ClientResult(test_id="test_123", result="invalid_status")
+
+        error_str = str(exc_info.value)
+        # Should mention the valid enum values
+        assert "must be one of enum values" in error_str
+        assert "passed" in error_str
+        assert "failed" in error_str
+        assert "error" in error_str
+
+    def test_field_validator_is_classmethod(self):
+        """Test that field validators are implemented as class methods."""
+        # This is a structural test to ensure the Pydantic v2 fix is in place
+        from ibutsu_client.models.result import Result
+
+        # The validator should exist and be accessible
+        validator_method = getattr(Result, "result_validate_enum", None)
+        assert validator_method is not None
+
+        # Should be callable (classmethod behavior)
+        assert callable(validator_method)
+
+    def test_model_instantiation_with_validator(self):
+        """Test that models can be instantiated successfully with validators active."""
+        # This tests that the @classmethod fix doesn't break normal instantiation
+        result = ClientResult(
+            test_id="validator_test",
+            result="passed",
+            component="auth",
+            env="production",
+        )
+
+        assert result.test_id == "validator_test"
+        assert result.result == "passed"
+        assert result.component == "auth"
+
+    def test_validator_with_none_values(self):
+        """Test that validators handle None values correctly."""
+        # Result field is optional and can be None in some contexts
+        result = ClientResult(test_id="none_test")
+        # Default should be None or a valid enum value
+        assert result.result in [
+            None,
+            "passed",
+            "failed",
+            "error",
+            "skipped",
+            "xpassed",
+            "xfailed",
+            "manual",
+            "blocked",
+        ]
+
+    def test_json_serialization_with_validators(self):
+        """Test that JSON serialization works with field validators active."""
+        result = ClientResult(
+            test_id="json_test",
+            result="failed",
+            component="database",
+            env="staging",
+            metadata={"error": "Connection timeout"},
+            duration=30.5,
+        )
+
+        # Should serialize to JSON without issues
+        json_str = result.model_dump_json()
+        assert isinstance(json_str, str)
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed["test_id"] == "json_test"
+        assert parsed["result"] == "failed"
+
+    def test_model_copy_with_validators(self):
+        """Test that model copying works with field validators."""
+        original = ClientResult(test_id="copy_test", result="passed")
+
+        # Should be able to copy with valid changes
+        copied = original.model_copy(update={"result": "failed"})
+        assert copied.result == "failed"
+        assert copied.test_id == "copy_test"
+
+        # Note: model_copy doesn't re-validate, so we test initial creation validation instead
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="copy_test", result="invalid_value")
+
+
+class TestUUIDImportConsolidation:
+    """Test that UUID import consolidation doesn't break functionality."""
+
+    def test_uuid_fields_in_result_model(self):
+        """Test that UUID fields work correctly in Result model."""
+        test_uuid = uuid.uuid4()
+        run_uuid = uuid.uuid4()
+        project_uuid = uuid.uuid4()
+
+        result = ClientResult(
+            test_id="uuid_test", id=test_uuid, run_id=run_uuid, project_id=project_uuid
+        )
+
+        assert result.id == test_uuid
+        assert result.run_id == run_uuid
+        assert result.project_id == project_uuid
+
+    def test_uuid_fields_in_run_model(self):
+        """Test that UUID fields work correctly in Run model."""
+        run_uuid = uuid.uuid4()
+        project_uuid = uuid.uuid4()
+
+        run = ClientRun(
+            id=run_uuid, project_id=project_uuid, component="api", env="test"
+        )
+
+        assert run.id == run_uuid
+        assert run.project_id == project_uuid
+
+    def test_uuid_string_conversion(self):
+        """Test that UUID string conversion works correctly."""
+        uuid_str = str(uuid.uuid4())
+
+        result = ClientResult(test_id="string_uuid_test", id=uuid_str)
+
+        # Should accept string UUIDs and convert appropriately
+        assert str(result.id) == uuid_str
+
+    @pytest.mark.parametrize(
+        "invalid_uuid",
+        [
+            "not-a-uuid",
+            "12345678-1234-1234-1234",  # Too short
+            "12345678-1234-1234-1234-12345678901234",  # Too long
+            "",
+            "random-string",
+        ],
+    )
+    def test_uuid_validation_with_invalid_strings(self, invalid_uuid):
+        """Test that invalid UUID strings are properly rejected."""
+        with pytest.raises(ValidationError):
+            ClientResult(test_id="invalid_uuid_test", id=invalid_uuid)
+
+    def test_uuid_fields_json_serialization(self):
+        """Test that UUID fields serialize correctly to JSON."""
+        test_uuid = uuid.uuid4()
+
+        result = ClientResult(test_id="uuid_json_test", id=test_uuid, result="passed")
+
+        json_str = result.model_dump_json()
+        parsed = json.loads(json_str)
+
+        # UUID should be serialized as string
+        assert parsed["id"] == str(test_uuid)
+        assert isinstance(parsed["id"], str)
+
+    def test_all_models_can_be_imported(self):
+        """Test that all client models can be imported successfully."""
+        # This tests that the UUID import consolidation doesn't break imports
+        from ibutsu_client.models.result import Result
+        from ibutsu_client.models.run import Run
+        from ibutsu_client.models.project import Project
+        from ibutsu_client.models.artifact import Artifact
+
+        # Should be able to instantiate basic instances
+        models_to_test = [
+            (Result, {"test_id": "test"}),
+            (Run, {}),
+            (Project, {"name": "test_project"}),
+            (Artifact, {}),
+        ]
+
+        for model_class, kwargs in models_to_test:
+            try:
+                instance = model_class(**kwargs)
+                assert instance is not None
+            except Exception as e:
+                pytest.fail(f"Failed to instantiate {model_class.__name__}: {e}")
+
+    @pytest.mark.parametrize(
+        "model_class,kwargs",
+        [
+            (
+                lambda: __import__(
+                    "ibutsu_client.models.result", fromlist=["Result"]
+                ).Result,
+                {"test_id": "test"},
+            ),
+            (lambda: __import__("ibutsu_client.models.run", fromlist=["Run"]).Run, {}),
+            (
+                lambda: __import__(
+                    "ibutsu_client.models.project", fromlist=["Project"]
+                ).Project,
+                {"name": "test_project"},
+            ),
+            (
+                lambda: __import__(
+                    "ibutsu_client.models.artifact", fromlist=["Artifact"]
+                ).Artifact,
+                {},
+            ),
+        ],
+    )
+    def test_model_instantiation_parametrized(self, model_class, kwargs):
+        """Test that different client models can be instantiated with basic data."""
+        model_cls = model_class()  # Call the lambda to get the actual class
+        try:
+            instance = model_cls(**kwargs)
+            assert instance is not None
+        except Exception as e:
+            pytest.fail(f"Failed to instantiate {model_cls.__name__}: {e}")
+
+
+class TestModelValidationEdgeCases:
+    """Test edge cases in model validation."""
+
+    def test_result_model_with_all_fields(self):
+        """Test Result model with all possible fields populated."""
+        result = ClientResult(
+            id=uuid.uuid4(),
+            test_id="comprehensive_test",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=45.5,
+            result="failed",
+            component="payment",
+            env="production",
+            run_id=uuid.uuid4(),
+            project_id=uuid.uuid4(),
+            metadata={
+                "error_type": "TimeoutError",
+                "stack_trace": "Full stack trace here...",
+                "browser": "chrome",
+                "version": "95.0",
+                "retry_count": 3,
+            },
+            params={
+                "amount": 100.50,
+                "currency": "USD",
+                "payment_method": "credit_card",
+            },
+            source="pytest-ibutsu",
+        )
+
+        # Should be valid and serializable
+        json_str = result.model_dump_json()
+        assert len(json_str) > 0
+
+        # Should be deserializable
+        parsed = json.loads(json_str)
+        recreated = ClientResult(**parsed)
+        assert recreated.test_id == "comprehensive_test"
+        assert recreated.result == "failed"
+
+    def test_run_model_with_all_fields(self):
+        """Test Run model with all possible fields populated."""
+        run = ClientRun(
+            id=uuid.uuid4(),
+            component="e2e-tests",
+            env="staging",
+            project_id=uuid.uuid4(),
+            metadata={
+                "jenkins": {
+                    "job_name": "nightly-e2e",
+                    "build_number": "789",
+                    "build_url": "http://jenkins.example.com/job/nightly-e2e/789",
+                },
+                "git": {
+                    "commit": "abc123def456",
+                    "branch": "feature/new-payment",
+                    "author": "developer@example.com",
+                },
+                "environment": {
+                    "database_version": "13.4",
+                    "api_version": "2.1.0",
+                    "frontend_version": "1.5.2",
+                },
+            },
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=1800.0,  # 30 minutes
+        )
+
+        # Should be valid and serializable
+        json_str = run.model_dump_json()
+        assert len(json_str) > 0
+
+        # Should be deserializable
+        parsed = json.loads(json_str)
+        recreated = ClientRun(**parsed)
+        assert recreated.component == "e2e-tests"
+        assert recreated.env == "staging"
+
+    def test_nested_metadata_validation(self):
+        """Test that deeply nested metadata is handled correctly."""
+        complex_metadata = {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "test_data": [1, 2, 3],
+                        "config": {
+                            "timeout": 30,
+                            "retries": 3,
+                            "endpoints": {
+                                "api": "http://api.example.com",
+                                "auth": "http://auth.example.com",
+                            },
+                        },
+                    }
+                }
+            },
+            "parallel_data": {
+                "browser_configs": [
+                    {"name": "chrome", "version": "95.0"},
+                    {"name": "firefox", "version": "93.0"},
+                ]
+            },
+        }
+
+        result = ClientResult(test_id="nested_metadata_test", metadata=complex_metadata)
+
+        # Should handle complex nested structures
+        assert result.metadata["level1"]["level2"]["level3"]["test_data"] == [1, 2, 3]
+        assert (
+            result.metadata["parallel_data"]["browser_configs"][0]["name"] == "chrome"
+        )
+
+    def test_special_characters_in_strings(self):
+        """Test handling of special characters in string fields."""
+        special_chars_data = {
+            "test_id": "test_with_ñáéíóú_and_中文_and_🚀",
+            "component": "auth-with-special-chars_äöü",
+            "env": "test-environment_with_hyphen-and_underscore",
+            "result": "passed",
+            "metadata": {
+                "error_message": "Error with quotes: \"nested quotes\" and 'single quotes'",
+                "unicode_test": "Testing unicode: ñáéíóú 中文 🚀 🎉",
+                "special_symbols": "Test with symbols: @#$%^&*()_+-=[]{}|;:,.<>?",
+            },
+        }
+
+        result = ClientResult(**special_chars_data)
+
+        # Should handle special characters correctly
+        assert "ñáéíóú" in result.test_id
+        assert "中文" in result.test_id
+        assert "🚀" in result.test_id
+
+        # Should serialize and deserialize correctly
+        json_str = result.model_dump_json()
+        parsed = json.loads(json_str)
+        recreated = ClientResult(**parsed)
+
+        assert recreated.test_id == special_chars_data["test_id"]
+        assert (
+            recreated.metadata["unicode_test"]
+            == special_chars_data["metadata"]["unicode_test"]
+        )
+
+    def test_large_metadata_handling(self):
+        """Test handling of large metadata objects."""
+        # Create a large metadata object
+        large_metadata = {
+            f"key_{i}": {
+                "data": list(range(100)),
+                "text": "Large text field with repeated content " * 50,
+                "nested": {f"nested_key_{j}": f"nested_value_{j}" for j in range(50)},
+            }
+            for i in range(10)
+        }
+
+        result = ClientResult(test_id="large_metadata_test", metadata=large_metadata)
+
+        # Should handle large metadata without issues
+        assert len(result.metadata) == 10
+        assert len(result.metadata["key_0"]["data"]) == 100
+
+        # Should be serializable (though it might be large)
+        json_str = result.model_dump_json()
+        assert len(json_str) > 1000  # Should be a substantial JSON string
+
+    @pytest.mark.parametrize(
+        "test_data",
+        [
+            # Duration boundary values - positive
+            {"duration": 0.0},
+            {"duration": 0.001},  # Very small positive
+            {"duration": 999999.999},  # Very large
+            # Duration boundary values - negative and special
+            {"duration": -0.001},  # Very small negative
+            {"duration": -999999.999},  # Very large negative
+            {"duration": float("nan")},  # NaN
+            {"duration": float("inf")},  # Infinity
+            {"duration": float("-inf")},  # -Infinity
+            # Metadata with boundary values - positive
+            {"metadata": {"count": 0}},
+            {"metadata": {"count": 2**31 - 1}},  # Max 32-bit int
+            {"metadata": {"ratio": 0.0}},
+            {"metadata": {"ratio": 1.0}},
+            # Metadata with boundary values - negative and special
+            {"metadata": {"count": -1}},  # Negative count
+            {"metadata": {"count": -(2**31)}},  # Min 32-bit int
+            {"metadata": {"ratio": -1.0}},  # Negative ratio
+            {"metadata": {"ratio": float("nan")}},  # NaN ratio
+            {"metadata": {"ratio": float("inf")}},  # Infinity ratio
+            {"metadata": {"ratio": float("-inf")}},  # -Infinity ratio
+        ],
+    )
+    def test_boundary_values(self, test_data):
+        """Test boundary values for numeric fields including negative and NaN values."""
+        result = ClientResult(test_id="boundary_test", **test_data)
+        # Should create successfully without validation errors
+        assert result.test_id == "boundary_test"
+
+    def test_empty_and_null_values(self):
+        """Test handling of empty and null values."""
+        # Test with minimal required fields only
+        minimal_result = ClientResult(test_id="minimal")
+        assert minimal_result.test_id == "minimal"
+
+        # Test with explicit None values for optional fields
+        result_with_nones = ClientResult(
+            test_id="nones_test",
+            component=None,
+            env=None,
+            run_id=None,
+            project_id=None,
+            metadata=None,
+            params=None,
+        )
+        assert result_with_nones.test_id == "nones_test"
+        assert result_with_nones.component is None
+
+        # Test with empty collections
+        result_with_empties = ClientResult(
+            test_id="empties_test", metadata={}, params={}
+        )
+        assert result_with_empties.metadata == {}
+        assert result_with_empties.params == {}
+
+
+class TestRealWorldScenarios:
+    """Test real-world usage scenarios for model validation."""
+
+    def test_pytest_parameterized_test_result(self):
+        """Test result from a parameterized pytest test."""
+        # Simulate a parameterized test result
+        result = ClientResult(
+            test_id="test_login[user1-password1]",
+            result="passed",
+            component="authentication",
+            env="staging",
+            source="pytest-ibutsu",
+            duration=1.25,
+            metadata={
+                "markers": [
+                    {
+                        "name": "parametrize",
+                        "args": [
+                            "username,password",
+                            [("user1", "password1"), ("user2", "password2")],
+                        ],
+                        "kwargs": {},
+                    }
+                ],
+                "node_id": "tests/test_auth.py::test_login[user1-password1]",
+                "fspath": "tests/test_auth.py",
+            },
+            params={"username": "user1", "password": "password1"},
+        )
+
+        assert result.test_id == "test_login[user1-password1]"
+        assert result.params["username"] == "user1"
+        assert "parametrize" in [m["name"] for m in result.metadata["markers"]]
+
+    def test_failed_test_with_exception_info(self):
+        """Test result from a failed test with exception information."""
+        result = ClientResult(
+            test_id="test_database_connection",
+            result="failed",
+            component="database",
+            env="production",
+            source="pytest-ibutsu",
+            duration=5.0,
+            metadata={
+                "exception_name": "ConnectionError",
+                "short_tb": "ConnectionError: Could not connect to database\n  at database.py:45",
+                "statuses": {
+                    "setup": ("passed", False),
+                    "call": ("failed", False),
+                    "teardown": ("passed", False),
+                },
+                "durations": {"setup": 0.1, "call": 4.8, "teardown": 0.1},
+                "classification": "environment_failure",
+            },
+        )
+
+        assert result.result == "failed"
+        assert result.metadata["exception_name"] == "ConnectionError"
+        assert result.metadata["classification"] == "environment_failure"
+
+    def test_xfailed_test_result(self):
+        """Test result from an expected failure (xfail)."""
+        result = ClientResult(
+            test_id="test_known_bug",
+            result="xfailed",
+            component="payments",
+            env="test",
+            source="pytest-ibutsu",
+            duration=0.5,
+            metadata={
+                "markers": [
+                    {
+                        "name": "xfail",
+                        "args": [],
+                        "kwargs": {
+                            "reason": "Known issue with payment gateway",
+                            "strict": False,
+                        },
+                    }
+                ],
+                "xfail_reason": "Known issue with payment gateway",
+                "statuses": {"setup": ("passed", False), "call": ("skipped", True)},
+            },
+        )
+
+        assert result.result == "xfailed"
+        assert result.metadata["xfail_reason"] == "Known issue with payment gateway"
+
+    def test_integration_test_run(self):
+        """Test run data from a comprehensive integration test suite."""
+        run = ClientRun(
+            component="full-stack-integration",
+            env="staging",
+            source="pytest-ibutsu",
+            start_time=datetime.now(UTC).isoformat(),
+            duration=1200.0,  # 20 minutes
+            metadata={
+                "jenkins": {
+                    "job_name": "integration-tests",
+                    "build_number": "567",
+                    "build_url": "http://jenkins.example.com/job/integration-tests/567",
+                },
+                "environment": {
+                    "api_version": "v2.3.1",
+                    "database_version": "PostgreSQL 13.4",
+                    "redis_version": "6.2.5",
+                    "elasticsearch_version": "7.15.0",
+                },
+                "test_counts": {"total": 45, "passed": 42, "failed": 2, "skipped": 1},
+                "git_info": {
+                    "commit": "a1b2c3d4e5f6",
+                    "branch": "develop",
+                    "author": "dev-team@example.com",
+                },
+            },
+        )
+
+        assert run.component == "full-stack-integration"
+        assert run.duration == 1200.0
+        assert run.metadata["test_counts"]["total"] == 45
+        assert run.metadata["jenkins"]["job_name"] == "integration-tests"


### PR DESCRIPTION
Add tests to evaluate the major version update for the ibutsu-client.

https://github.com/ibutsu/ibutsu-client-python/commit/92264c4c21b738f8b7aff5a359a375f2442e50c0


## Summary by Sourcery

Introduce a comprehensive suite of integration and compatibility tests for the ibutsu-client-python release, validating Pydantic v2 model behavior, model conversions, API interactions, and real-world edge cases.

Tests:
- Add integration tests for ClientResult and ClientRun models, covering instantiation, field validation, JSON/dict serialization, UUID handling, and Pydantic v2 validator behavior
- Add conversion tests from pytest-ibutsu’s IbutsuTestResult and IbutsuTestRun to client models, verifying field mapping and backward-compatibility of defaults
- Add unit tests for the IbutsuSender module, mocking API calls to validate result/run submission flows, artifact uploads, error and network failure handling, and async request support
- Add end-to-end API integration tests simulating real-world scenarios, including full run/result submission flows with mocked endpoints, concurrency cases, and complex metadata handling
- Add edge-case tests for deeply nested/large metadata, special character support, numeric and boundary value validation, and real-world parameterized and xdist parallel execution scenarios