### PR TITLE
Excessive logging on parametrization reference

### DIFF
--- a/src/pytest_ibutsu/modeling.py
+++ b/src/pytest_ibutsu/modeling.py
@@ -216,8 +216,10 @@ class IbutsuTestResult:
         try:
             params = item.callspec.params.items()  # type: ignore[attr-defined]
             return {p: get_name(v) for p, v in params}
+        except AttributeError:
+            return {}
         except Exception as e:
-            log.warning("%s %s", item, e)
+            log.debug("%s %s", item, e)
             return {}
 
     @staticmethod


### PR DESCRIPTION
don't even log if it's an attribute error, that's expected

Move other exceptions to debug logging