### PR TITLE
Appending server_url for project_id resolve

### DIFF
--- a/src/pytest_ibutsu/api_config.py
+++ b/src/pytest_ibutsu/api_config.py
@@ -1,0 +1,49 @@
+import os
+
+from ibutsu_client.configuration import Configuration
+
+CA_BUNDLE_ENVS = ["REQUESTS_CA_BUNDLE", "IBUTSU_CA_BUNDLE"]
+
+
+def normalize_server_url(server_url: str) -> str:
+    """Normalize server URL to ensure it ends with /api.
+
+    Args:
+        server_url: Raw server URL (may or may not include /api suffix)
+
+    Returns:
+        Normalized URL ending with /api
+    """
+    url = server_url.rstrip("/")
+    if not url.endswith("/api"):
+        url += "/api"
+    return url
+
+
+def create_api_configuration(
+    server_url: str,
+    access_token: str | None = None,
+    *,
+    use_ssl_ca_cert: bool = True,
+) -> Configuration:
+    """This handles URL normalization and common configuration setup.
+
+    Args:
+        server_url: Server URL (with or without /api suffix, with or without trailing slash)
+        access_token: JWT token for authentication
+        use_ssl_ca_cert: Whether to configure SSL CA cert from environment variables
+
+    Returns:
+        Configured ibutsu_client Configuration instance
+    """
+    normalized_url = normalize_server_url(server_url)
+    config = Configuration(access_token=access_token, host=normalized_url)
+
+    if use_ssl_ca_cert:
+        for env_var in CA_BUNDLE_ENVS:
+            ca_cert = os.getenv(env_var)
+            if ca_cert:
+                config.ssl_ca_cert = ca_cert
+                break
+
+    return config

--- a/src/pytest_ibutsu/pytest_plugin.py
+++ b/src/pytest_ibutsu/pytest_plugin.py
@@ -17,8 +17,10 @@ from typing import Generator, Any, TYPE_CHECKING
 from typing import Iterator
 
 from ibutsu_client.api_client import ApiClient
-from ibutsu_client.configuration import Configuration
 from ibutsu_client.api.project_api import ProjectApi
+from ibutsu_client.exceptions import NotFoundException
+
+from .api_config import create_api_configuration  # Local import
 
 if TYPE_CHECKING:
     from _pytest.terminal import TerminalReporter
@@ -141,10 +143,20 @@ class IbutsuPlugin:
             return project_value
 
         # Query the Ibutsu server to get the UUID
-        config = Configuration(access_token=self.ibutsu_token, host=self.ibutsu_server)
+        logger.info(f"Using server: {self.ibutsu_server}")
+
+        config = create_api_configuration(
+            self.ibutsu_server, self.ibutsu_token, use_ssl_ca_cert=False
+        )
         project_api = ProjectApi(ApiClient(config))
 
-        response = project_api.get_project_list(filter=[f"name={project_value}"])
+        try:
+            response = project_api.get_project_list(filter=[f"name={project_value}"])
+        except NotFoundException:
+            logger.warning(
+                f"Could not find '{project_value}' on '{self.ibutsu_server}' (404)."
+            )
+            return project_value
 
         if response.projects and len(response.projects) > 0:
             resolved_uuid = str(response.projects[0].id)

--- a/src/pytest_ibutsu/sender.py
+++ b/src/pytest_ibutsu/sender.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from functools import cached_property
 from http.client import BadStatusLine
@@ -12,11 +11,12 @@ from typing import TypeVar, ParamSpec
 
 from ibutsu_client.api_client import ApiClient
 from ibutsu_client.exceptions import ApiException, ApiValueError
-from ibutsu_client.configuration import Configuration
 from ibutsu_client.api.artifact_api import ArtifactApi
 from ibutsu_client.api.health_api import HealthApi
 from ibutsu_client.api.result_api import ResultApi
 from ibutsu_client.api.run_api import RunApi
+
+from .api_config import create_api_configuration  # Local import
 from urllib3.exceptions import MaxRetryError
 from urllib3.exceptions import ProtocolError
 from urllib3.exceptions import NewConnectionError
@@ -41,8 +41,6 @@ RETRY_BASE_DELAY = 1.0
 
 # Backoff factor for exponential delay
 RETRY_BACKOFF_FACTOR = 2.0
-
-CA_BUNDLE_ENVS = ["REQUESTS_CA_BUNDLE", "IBUTSU_CA_BUNDLE"]
 
 logger = logging.getLogger(__name__)
 
@@ -212,11 +210,7 @@ class IbutsuSender:
         self._has_server_error = False
         self._server_error_tbs: list[str] = []
         self._sender_cache: list[Any] = []
-        config = Configuration(access_token=token, host=server_url)
-        # Only set the SSL CA cert if one of the environment variables is set
-        for env_var in CA_BUNDLE_ENVS:
-            if os.getenv(env_var, None):
-                config.ssl_ca_cert = os.getenv(env_var)
+        config = create_api_configuration(server_url, token)
         api_client = ApiClient(config)
         self.result_api = ResultApi(api_client)
         self.artifact_api = ArtifactApi(api_client)
@@ -226,12 +220,7 @@ class IbutsuSender:
     @classmethod
     def from_ibutsu_plugin(cls, ibutsu: IbutsuPlugin) -> IbutsuSender:
         logger.info(f"Ibutsu server: {ibutsu.ibutsu_server}")
-        ibutsu_server = ibutsu.ibutsu_server
-        if ibutsu.ibutsu_server.endswith("/"):
-            ibutsu_server = ibutsu_server[:-1]
-        if not ibutsu.ibutsu_server.endswith("/api"):
-            ibutsu_server += "/api"
-        return cls(server_url=ibutsu_server, token=ibutsu.ibutsu_token)
+        return cls(server_url=ibutsu.ibutsu_server, token=ibutsu.ibutsu_token)
 
     @property
     def frontend_url(self) -> str:

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -11,9 +11,9 @@ from pytest_ibutsu.sender import (
     IbutsuSender,
     send_data_to_ibutsu,
     UPLOAD_LIMIT,
-    CA_BUNDLE_ENVS,
     MAX_CALL_RETRIES,
 )
+from pytest_ibutsu.api_config import CA_BUNDLE_ENVS
 from pytest_ibutsu.modeling import IbutsuTestRun, IbutsuTestResult
 
 
@@ -91,20 +91,22 @@ class TestIbutsuSender:
 
         with patch.object(IbutsuSender, "__init__", return_value=None) as mock_init:
             _ = IbutsuSender.from_ibutsu_plugin(mock_plugin)
+            # Raw URL is passed; normalization happens inside __init__ via create_api_configuration
             mock_init.assert_called_once_with(
-                server_url="http://example.com/api", token="test-token"
+                server_url="http://example.com", token="test-token"
             )
 
     def test_from_ibutsu_plugin_with_trailing_slash(self):
-        """Test URL handling with trailing slash."""
+        """Test URL handling with trailing slash - normalization happens in __init__."""
         mock_plugin = Mock()
         mock_plugin.ibutsu_server = "http://example.com/"
         mock_plugin.ibutsu_token = "test-token"
 
         with patch.object(IbutsuSender, "__init__", return_value=None) as mock_init:
             _ = IbutsuSender.from_ibutsu_plugin(mock_plugin)
+            # Raw URL is passed; normalization happens inside __init__ via create_api_configuration
             mock_init.assert_called_once_with(
-                server_url="http://example.com/api", token="test-token"
+                server_url="http://example.com/", token="test-token"
             )
 
     def test_from_ibutsu_plugin_with_api_suffix(self):


### PR DESCRIPTION
To solve this 
```
File "/iqe_venv/lib/python3.12/site-packages/pytest_ibutsu/pytest_plugin.py", line 641, in pytest_terminal_summary
f"✓ Results uploaded to: {summary['frontend_url']}/project/{plugin.project_uuid}/runs/{plugin.run.id}"
```

## Summary by Sourcery

Resolve Ibutsu project UUIDs against the API endpoint instead of the raw server URL and handle missing projects gracefully.

Bug Fixes:
- Normalize the Ibutsu server URL to point to the `/api` endpoint when resolving project IDs.
- Handle 404 Not Found errors when looking up projects by name and fall back to the configured project value.