### PR TITLE
[IQE-3809] Update default for ibutsu source

### DIFF
--- a/src/pytest_ibutsu/pytest_plugin.py
+++ b/src/pytest_ibutsu/pytest_plugin.py
@@ -514,8 +514,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         dest="ibutsu_source",
         action="store",
         metavar="SOURCE",
-        default="local",
-        help="set the source for the tests",
+        default=None,
+        help="set the source for the tests (default: IBUTSU_SOURCE env or 'local')",
     )
     group.addoption(
         "--ibutsu-data",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -113,6 +113,50 @@ def test_valid_token(isolate_ibutsu_env_vars: None, pytester: pytest.Pytester):
     IbutsuPlugin.from_config(test_config)
 
 
+def test_ibutsu_source_default_when_unset(
+    isolate_ibutsu_env_vars: None, pytester: pytest.Pytester
+):
+    """Test ibutsu_source is 'local' when neither --ibutsu-source nor IBUTSU_SOURCE is set."""
+    test_config = pytester.parseconfig(
+        "--ibutsu", "archive", "--ibutsu-project", "test-project"
+    )
+    plugin = IbutsuPlugin.from_config(test_config)
+    assert plugin.ibutsu_source == "local"
+
+
+def test_ibutsu_source_from_env_when_cli_not_passed(
+    isolate_ibutsu_env_vars: None,
+    pytester: pytest.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test IBUTSU_SOURCE env is used when --ibutsu-source is not passed (CLI default is None)."""
+    monkeypatch.setenv("IBUTSU_SOURCE", "my-ci-run")
+    test_config = pytester.parseconfig(
+        "--ibutsu", "archive", "--ibutsu-project", "test-project"
+    )
+    plugin = IbutsuPlugin.from_config(test_config)
+    assert plugin.ibutsu_source == "my-ci-run"
+
+
+def test_ibutsu_source_cli_overrides_env(
+    isolate_ibutsu_env_vars: None,
+    pytester: pytest.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test --ibutsu-source takes precedence over IBUTSU_SOURCE when both are set."""
+    monkeypatch.setenv("IBUTSU_SOURCE", "env-source-value")
+    test_config = pytester.parseconfig(
+        "--ibutsu",
+        "archive",
+        "--ibutsu-project",
+        "test-project",
+        "--ibutsu-source",
+        "cli-source-value",
+    )
+    plugin = IbutsuPlugin.from_config(test_config)
+    assert plugin.ibutsu_source == "cli-source-value"
+
+
 def test_ibutsu_data_single_pair(
     isolate_ibutsu_env_vars: None, pytester: pytest.Pytester
 ):


### PR DESCRIPTION
## Summary by Sourcery

Adjust ibutsu source configuration defaults and document their behavior.

Enhancements:
- Change the --ibutsu-source CLI option to default to None and clarify help text to describe resolution via IBUTSU_SOURCE or 'local'.

Tests:
- Add tests verifying ibutsu_source defaults to 'local' when unset and is taken from the IBUTSU_SOURCE environment variable when the CLI option is not provided.